### PR TITLE
Adding Atuin Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/atuin/main.tf
+++ b/atuin/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "digitalocean_droplet" "atuin-server" {
+  image   = "docker-20-04"
+  name    = "atuin-server"
+  region  = "nyc2"
+  size    = "s-1vcpu-1gb"
+  backups = true
+  backup_policy {
+    plan    = "weekly"
+    weekday = "TUE"
+    hour    = 8
+  }
+  ssh_keys = [44628444, 30997463]
+}

--- a/main.tf
+++ b/main.tf
@@ -17,21 +17,6 @@ terraform {
     }
   }
 }
-
-variable "DO_PAT" {
-  type    = string
-  default = ""
-}
-
-variable "AWS_ACCESS_KEY_ID" {
-  type    = string
-  default = ""
-}
-
-variable "AWS_SECRET_ACCESS_KEY" {
-  type    = string
-  default = ""
-}
 provider "digitalocean" {
   token = var.DO_PAT
 }
@@ -40,4 +25,8 @@ provider "aws" {
   region     = "us-east-1"
   access_key = var.AWS_ACCESS_KEY_ID
   secret_key = var.AWS_SECRET_ACCESS_KEY
+}
+
+module "atuin" {
+  source = "./atuin"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "DO_PAT" {
+  type    = string
+  default = ""
+}
+
+variable "AWS_ACCESS_KEY_ID" {
+  type    = string
+  default = ""
+}
+
+variable "AWS_SECRET_ACCESS_KEY" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
Atuin Server is using for sync shell history across machines. https://atuin.sh/. Requires both a binary server and a postgres database, storing them both on same machine according to this: https://docs.atuin.sh/self-hosting/docker/