### PR TITLE
Updating Output Firewall rules

### DIFF
--- a/atuin/main.tf
+++ b/atuin/main.tf
@@ -60,4 +60,16 @@ resource "digitalocean_firewall" "atuin-server" {
     port_range       = "8888"
     source_addresses = ["0.0.0.0/0", "::/0"]
   }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
 }


### PR DESCRIPTION
Without output rules, atuin server fails to connect to postgres despite it being in the VNC. 

Also the ubuntu server need 8888 port exposed using UFW